### PR TITLE
Fix: Prevent IndexOutOfBoundsException in resetFromParam

### DIFF
--- a/app/src/main/java/com/jpaver/trianglelist/MainActivity.kt
+++ b/app/src/main/java/com/jpaver/trianglelist/MainActivity.kt
@@ -1629,7 +1629,11 @@ class MainActivity : AppCompatActivity(),
 
     private fun processTriEditMode(strAddLineB: String, strAddLineC: String, inputLineAdd: InputParameter, inputLineEdit: InputParameter) {
         when {
-            strAddLineB.isEmpty() -> {
+            strAddLineB.isEmpty() -> { // Edit attempt
+                if (trianglelist.size() == 0) {
+                    showToast("Cannot edit: The list is empty. Add a triangle first.")
+                    return // Exit early
+                }
                 resetTrianglesBy( inputLineEdit )
                 showToast("Rewrite Triangle")
             }
@@ -1871,6 +1875,14 @@ class MainActivity : AppCompatActivity(),
 
     private fun resetTrianglesBy(params: InputParameter) : Boolean {
 
+        if (trianglelist.size() == 0) {
+            showToast("Cannot edit: The list is empty. Add a triangle first.")
+            return false
+        }
+        if (params.number <= 0 || params.number > trianglelist.size()) {
+            showToast("Cannot edit: Invalid triangle number ${params.number}.")
+            return false
+        }
         return if (isParamsValid(params)){
             trilistUndo = trianglelist.clone()
             fab_undo.backgroundTintList = getColorStateList(R.color.colorLime)

--- a/app/src/main/java/com/jpaver/trianglelist/TriangleList.kt
+++ b/app/src/main/java/com/jpaver/trianglelist/TriangleList.kt
@@ -508,7 +508,15 @@ open class TriangleList : EditList {
     }
 
     fun resetFromParam(prms: InputParameter): Boolean {
+        if (trilist.isEmpty()) {
+            Log.e("TriangleList", "resetFromParam: trilist is empty. Cannot reset.")
+            return false
+        }
         val ci = prms.number - 1
+        if (ci < 0 || ci >= trilist.size) {
+            Log.e("TriangleList", "resetFromParam: Index ci (${prms.number}-1) is out of bounds for trilist size ${trilist.size()}.")
+            return false
+        }
         val tri = trilist[ci]
 
         // 親番号が書き換わっている時は入れ替える。ただし現在のリストの範囲外の番号は除く。


### PR DESCRIPTION
The `IndexOutOfBoundsException: Index 0 out of bounds for length 0` occurred in `TriangleList.resetFromParam` when attempting to access an element in an empty `trilist`. This typically happened if you tried an "edit" operation (via FAB replace with empty length fields) when the triangle list was empty.

This commit introduces the following changes:
1.  In `TriangleList.resetFromParam`: Added a guard clause at the beginning to check if `trilist` is empty or if the calculated index `ci` is out of bounds. If so, it logs an error and returns `false`.
2.  In `MainActivity.resetTrianglesBy`: Added checks before calling `trianglelist.resetFromParam`. If `trianglelist` is empty or the `params.number` is invalid for an edit, it shows a Toast message to you and returns `false`.
3.  In `MainActivity.processTriEditMode`: Added a specific check for the "edit" case (`strAddLineB.isEmpty()`). If `trianglelist` is empty, it shows a Toast and returns early, preventing the call to `resetTrianglesBy`.

These changes ensure the application handles the scenario gracefully, preventing the crash and providing appropriate feedback to you.