### PR TITLE
#22 Refactor TriangleList management structure

### DIFF
--- a/rust-trilib/src/model/mod.rs
+++ b/rust-trilib/src/model/mod.rs
@@ -1,3 +1,7 @@
 pub mod point;
+pub mod triangle;
+pub mod triangle_list;
 
 pub use point::PointXY;
+pub use triangle::{ConnectionType, Triangle};
+pub use triangle_list::TriangleList;

--- a/rust-trilib/src/model/triangle.rs
+++ b/rust-trilib/src/model/triangle.rs
@@ -1,0 +1,267 @@
+//! Triangle structure definition
+//!
+//! Represents a triangle with three edge lengths and optional connection information.
+
+use super::PointXY;
+
+/// Connection type between triangles
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ConnectionType {
+    /// Independent triangle (no connection)
+    #[default]
+    Independent = -1,
+    /// Connect to parent's B edge
+    ParentBEdge = 1,
+    /// Connect to parent's C edge
+    ParentCEdge = 2,
+}
+
+impl ConnectionType {
+    /// Create from i32 value
+    pub fn from_i32(value: i32) -> Self {
+        match value {
+            1 => ConnectionType::ParentBEdge,
+            2 => ConnectionType::ParentCEdge,
+            _ => ConnectionType::Independent,
+        }
+    }
+}
+
+/// Triangle with three edge lengths
+#[derive(Debug, Clone, PartialEq)]
+pub struct Triangle {
+    /// Triangle number (1-indexed)
+    number: i32,
+    /// Length of edge A (connection edge with parent)
+    pub length_a: f32,
+    /// Length of edge B (free edge)
+    pub length_b: f32,
+    /// Length of edge C (free edge)
+    pub length_c: f32,
+    /// Parent triangle number (-1 if independent)
+    pub parent_number: i32,
+    /// Connection type to parent
+    pub connection_type: ConnectionType,
+    /// Triangle name (optional)
+    pub name: String,
+    /// Vertex positions (calculated)
+    points: [PointXY; 3],
+}
+
+impl Default for Triangle {
+    fn default() -> Self {
+        Self {
+            number: 0,
+            length_a: 0.0,
+            length_b: 0.0,
+            length_c: 0.0,
+            parent_number: -1,
+            connection_type: ConnectionType::Independent,
+            name: String::new(),
+            points: [PointXY::zero(), PointXY::zero(), PointXY::zero()],
+        }
+    }
+}
+
+impl Triangle {
+    /// Create a new independent triangle with three edge lengths
+    pub fn new(length_a: f32, length_b: f32, length_c: f32) -> Self {
+        let mut tri = Self {
+            number: 0,
+            length_a,
+            length_b,
+            length_c,
+            parent_number: -1,
+            connection_type: ConnectionType::Independent,
+            name: String::new(),
+            points: [PointXY::zero(), PointXY::zero(), PointXY::zero()],
+        };
+        tri.calculate_points();
+        tri
+    }
+
+    /// Create a triangle connected to a parent
+    pub fn with_parent(
+        length_a: f32,
+        length_b: f32,
+        length_c: f32,
+        parent_number: i32,
+        connection_type: ConnectionType,
+    ) -> Self {
+        let mut tri = Self {
+            number: 0,
+            length_a,
+            length_b,
+            length_c,
+            parent_number,
+            connection_type,
+            name: String::new(),
+            points: [PointXY::zero(), PointXY::zero(), PointXY::zero()],
+        };
+        tri.calculate_points();
+        tri
+    }
+
+    /// Check if the triangle has valid edge lengths (triangle inequality)
+    pub fn is_valid(&self) -> bool {
+        if self.length_a <= 0.0 || self.length_b <= 0.0 || self.length_c <= 0.0 {
+            return false;
+        }
+        self.length_a + self.length_b > self.length_c
+            && self.length_b + self.length_c > self.length_a
+            && self.length_c + self.length_a > self.length_b
+    }
+
+    /// Get the triangle number
+    pub fn number(&self) -> i32 {
+        self.number
+    }
+
+    /// Set the triangle number
+    pub fn set_number(&mut self, number: i32) {
+        self.number = number;
+    }
+
+    /// Calculate the area using Heron's formula
+    pub fn area(&self) -> f32 {
+        if !self.is_valid() {
+            return 0.0;
+        }
+        let s = (self.length_a + self.length_b + self.length_c) / 2.0;
+        let area_squared =
+            s * (s - self.length_a) * (s - self.length_b) * (s - self.length_c);
+        if area_squared < 0.0 {
+            0.0
+        } else {
+            area_squared.sqrt()
+        }
+    }
+
+    /// Get the vertex points
+    pub fn points(&self) -> &[PointXY; 3] {
+        &self.points
+    }
+
+    /// Calculate vertex positions based on edge lengths
+    /// Point A is at origin, Point B is on the positive X axis
+    fn calculate_points(&mut self) {
+        if !self.is_valid() {
+            return;
+        }
+
+        // Point A at origin
+        self.points[0] = PointXY::zero();
+
+        // Point B on X axis at distance length_c from A
+        self.points[1] = PointXY::new(self.length_c, 0.0);
+
+        // Point C calculated using cosine rule
+        // cos(A) = (b² + c² - a²) / (2bc)
+        let cos_a = (self.length_b * self.length_b + self.length_c * self.length_c
+            - self.length_a * self.length_a)
+            / (2.0 * self.length_b * self.length_c);
+        let sin_a = (1.0 - cos_a * cos_a).sqrt();
+
+        self.points[2] = PointXY::new(self.length_b * cos_a, self.length_b * sin_a);
+    }
+
+    /// Check if this triangle is independent (not connected to any parent)
+    pub fn is_independent(&self) -> bool {
+        self.parent_number < 1 || self.connection_type == ConnectionType::Independent
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EPSILON: f32 = 0.001;
+
+    fn approx_eq(a: f32, b: f32) -> bool {
+        (a - b).abs() < EPSILON
+    }
+
+    #[test]
+    fn test_new_triangle() {
+        let tri = Triangle::new(3.0, 4.0, 5.0);
+        assert!(approx_eq(tri.length_a, 3.0));
+        assert!(approx_eq(tri.length_b, 4.0));
+        assert!(approx_eq(tri.length_c, 5.0));
+        assert!(tri.is_valid());
+    }
+
+    #[test]
+    fn test_invalid_triangle() {
+        let tri = Triangle::new(1.0, 2.0, 10.0);
+        assert!(!tri.is_valid());
+    }
+
+    #[test]
+    fn test_zero_edge() {
+        let tri = Triangle::new(0.0, 4.0, 5.0);
+        assert!(!tri.is_valid());
+    }
+
+    #[test]
+    fn test_area_345() {
+        let tri = Triangle::new(3.0, 4.0, 5.0);
+        // 3-4-5 right triangle area = (3 * 4) / 2 = 6
+        assert!(approx_eq(tri.area(), 6.0));
+    }
+
+    #[test]
+    fn test_area_equilateral() {
+        let tri = Triangle::new(2.0, 2.0, 2.0);
+        // Equilateral triangle with side 2: area = (√3 / 4) * 2² = √3
+        let expected = 3.0_f32.sqrt();
+        assert!(approx_eq(tri.area(), expected));
+    }
+
+    #[test]
+    fn test_area_invalid() {
+        let tri = Triangle::new(1.0, 2.0, 10.0);
+        assert!(approx_eq(tri.area(), 0.0));
+    }
+
+    #[test]
+    fn test_with_parent() {
+        let tri = Triangle::with_parent(5.0, 4.0, 3.0, 1, ConnectionType::ParentBEdge);
+        assert_eq!(tri.parent_number, 1);
+        assert_eq!(tri.connection_type, ConnectionType::ParentBEdge);
+        assert!(!tri.is_independent());
+    }
+
+    #[test]
+    fn test_independent() {
+        let tri = Triangle::new(3.0, 4.0, 5.0);
+        assert!(tri.is_independent());
+    }
+
+    #[test]
+    fn test_set_number() {
+        let mut tri = Triangle::new(3.0, 4.0, 5.0);
+        tri.set_number(1);
+        assert_eq!(tri.number(), 1);
+    }
+
+    #[test]
+    fn test_connection_type_from_i32() {
+        assert_eq!(ConnectionType::from_i32(-1), ConnectionType::Independent);
+        assert_eq!(ConnectionType::from_i32(1), ConnectionType::ParentBEdge);
+        assert_eq!(ConnectionType::from_i32(2), ConnectionType::ParentCEdge);
+        assert_eq!(ConnectionType::from_i32(99), ConnectionType::Independent);
+    }
+
+    #[test]
+    fn test_points_calculation() {
+        let tri = Triangle::new(3.0, 4.0, 5.0);
+        let points = tri.points();
+        // Point A at origin
+        assert!(approx_eq(points[0].x, 0.0));
+        assert!(approx_eq(points[0].y, 0.0));
+        // Point B on X axis at distance 5 (length_c)
+        assert!(approx_eq(points[1].x, 5.0));
+        assert!(approx_eq(points[1].y, 0.0));
+    }
+}

--- a/rust-trilib/src/model/triangle_list.rs
+++ b/rust-trilib/src/model/triangle_list.rs
@@ -1,0 +1,392 @@
+//! TriangleList management structure
+//!
+//! Manages a collection of triangles with automatic numbering and various operations.
+
+use std::ops::Index;
+
+use super::Triangle;
+
+/// A collection of triangles with automatic numbering
+#[derive(Debug, Clone, Default)]
+pub struct TriangleList {
+    /// Internal storage of triangles
+    triangles: Vec<Triangle>,
+}
+
+impl TriangleList {
+    /// Create a new empty TriangleList
+    pub fn new() -> Self {
+        Self {
+            triangles: Vec::new(),
+        }
+    }
+
+    /// Create a TriangleList with an initial triangle
+    pub fn with_first(triangle: Triangle) -> Self {
+        let mut list = Self::new();
+        list.add(triangle);
+        list
+    }
+
+    /// Add a triangle to the list with automatic numbering
+    ///
+    /// Returns the assigned number (1-indexed)
+    pub fn add(&mut self, mut triangle: Triangle) -> i32 {
+        let number = (self.triangles.len() + 1) as i32;
+        triangle.set_number(number);
+        self.triangles.push(triangle);
+        number
+    }
+
+    /// Get a triangle by number (1-indexed)
+    ///
+    /// Returns None if the number is out of range
+    pub fn get(&self, number: i32) -> Option<&Triangle> {
+        if number < 1 {
+            return None;
+        }
+        self.triangles.get((number - 1) as usize)
+    }
+
+    /// Get a mutable reference to a triangle by number (1-indexed)
+    ///
+    /// Returns None if the number is out of range
+    pub fn get_mut(&mut self, number: i32) -> Option<&mut Triangle> {
+        if number < 1 {
+            return None;
+        }
+        self.triangles.get_mut((number - 1) as usize)
+    }
+
+    /// Get the number of triangles in the list
+    pub fn size(&self) -> usize {
+        self.triangles.len()
+    }
+
+    /// Check if the list is empty
+    pub fn is_empty(&self) -> bool {
+        self.triangles.is_empty()
+    }
+
+    /// Clear all triangles from the list
+    pub fn clear(&mut self) {
+        self.triangles.clear();
+    }
+
+    /// Remove a triangle by number (1-indexed)
+    ///
+    /// Returns the removed triangle if successful, None otherwise.
+    /// Note: This operation renumbers all subsequent triangles.
+    pub fn remove(&mut self, number: i32) -> Option<Triangle> {
+        if number < 1 || number as usize > self.triangles.len() {
+            return None;
+        }
+
+        let removed = self.triangles.remove((number - 1) as usize);
+
+        // Renumber all triangles after the removed one
+        for (i, tri) in self.triangles.iter_mut().enumerate() {
+            tri.set_number((i + 1) as i32);
+        }
+
+        Some(removed)
+    }
+
+    /// Calculate the total area of all triangles
+    pub fn total_area(&self) -> f32 {
+        let area: f32 = self.triangles.iter().map(|t| t.area()).sum();
+        // Round to 2 decimal places like the Kotlin version
+        (area * 100.0).round() / 100.0
+    }
+
+    /// Get an iterator over the triangles
+    pub fn iter(&self) -> impl Iterator<Item = &Triangle> {
+        self.triangles.iter()
+    }
+
+    /// Get a mutable iterator over the triangles
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Triangle> {
+        self.triangles.iter_mut()
+    }
+
+    /// Get the last triangle in the list
+    pub fn last(&self) -> Option<&Triangle> {
+        self.triangles.last()
+    }
+
+    /// Get the first triangle in the list
+    pub fn first(&self) -> Option<&Triangle> {
+        self.triangles.first()
+    }
+}
+
+/// Index trait implementation for Vec-like access (1-indexed)
+///
+/// # Panics
+/// Panics if the index is out of bounds (< 1 or > size)
+impl Index<i32> for TriangleList {
+    type Output = Triangle;
+
+    fn index(&self, number: i32) -> &Self::Output {
+        self.get(number)
+            .unwrap_or_else(|| panic!("Triangle number {} is out of bounds", number))
+    }
+}
+
+/// Index trait for usize (0-indexed, like Vec)
+impl Index<usize> for TriangleList {
+    type Output = Triangle;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.triangles[index]
+    }
+}
+
+/// IntoIterator implementation for TriangleList
+impl IntoIterator for TriangleList {
+    type Item = Triangle;
+    type IntoIter = std::vec::IntoIter<Triangle>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.triangles.into_iter()
+    }
+}
+
+/// IntoIterator implementation for &TriangleList
+impl<'a> IntoIterator for &'a TriangleList {
+    type Item = &'a Triangle;
+    type IntoIter = std::slice::Iter<'a, Triangle>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.triangles.iter()
+    }
+}
+
+/// IntoIterator implementation for &mut TriangleList
+impl<'a> IntoIterator for &'a mut TriangleList {
+    type Item = &'a mut Triangle;
+    type IntoIter = std::slice::IterMut<'a, Triangle>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.triangles.iter_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EPSILON: f32 = 0.01;
+
+    fn approx_eq(a: f32, b: f32) -> bool {
+        (a - b).abs() < EPSILON
+    }
+
+    #[test]
+    fn test_new_empty() {
+        let list = TriangleList::new();
+        assert!(list.is_empty());
+        assert_eq!(list.size(), 0);
+    }
+
+    #[test]
+    fn test_add_and_get() {
+        let mut list = TriangleList::new();
+        let number = list.add(Triangle::new(3.0, 4.0, 5.0));
+
+        assert_eq!(number, 1);
+        assert_eq!(list.size(), 1);
+
+        let tri = list.get(1).unwrap();
+        assert_eq!(tri.number(), 1);
+        assert!(approx_eq(tri.length_a, 3.0));
+    }
+
+    #[test]
+    fn test_add_multiple() {
+        let mut list = TriangleList::new();
+        list.add(Triangle::new(3.0, 4.0, 5.0));
+        list.add(Triangle::new(5.0, 5.0, 5.0));
+        list.add(Triangle::new(6.0, 7.0, 8.0));
+
+        assert_eq!(list.size(), 3);
+        assert_eq!(list.get(1).unwrap().number(), 1);
+        assert_eq!(list.get(2).unwrap().number(), 2);
+        assert_eq!(list.get(3).unwrap().number(), 3);
+    }
+
+    #[test]
+    fn test_get_out_of_range() {
+        let list = TriangleList::new();
+        assert!(list.get(0).is_none());
+        assert!(list.get(1).is_none());
+        assert!(list.get(-1).is_none());
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut list = TriangleList::new();
+        list.add(Triangle::new(3.0, 4.0, 5.0));
+        list.add(Triangle::new(5.0, 5.0, 5.0));
+
+        assert_eq!(list.size(), 2);
+        list.clear();
+        assert!(list.is_empty());
+        assert_eq!(list.size(), 0);
+    }
+
+    #[test]
+    fn test_remove() {
+        let mut list = TriangleList::new();
+        list.add(Triangle::new(3.0, 4.0, 5.0));
+        list.add(Triangle::new(5.0, 5.0, 5.0));
+        list.add(Triangle::new(6.0, 7.0, 8.0));
+
+        let removed = list.remove(2);
+        assert!(removed.is_some());
+        assert_eq!(list.size(), 2);
+
+        // Check renumbering
+        assert_eq!(list.get(1).unwrap().number(), 1);
+        assert_eq!(list.get(2).unwrap().number(), 2);
+        // The triangle that was #3 is now #2
+        assert!(approx_eq(list.get(2).unwrap().length_a, 6.0));
+    }
+
+    #[test]
+    fn test_remove_invalid() {
+        let mut list = TriangleList::new();
+        list.add(Triangle::new(3.0, 4.0, 5.0));
+
+        assert!(list.remove(0).is_none());
+        assert!(list.remove(2).is_none());
+        assert!(list.remove(-1).is_none());
+        assert_eq!(list.size(), 1);
+    }
+
+    #[test]
+    fn test_total_area() {
+        let mut list = TriangleList::new();
+        // 3-4-5 triangle area = 6.0
+        list.add(Triangle::new(3.0, 4.0, 5.0));
+        // Equilateral triangle side 2, area = √3 ≈ 1.732
+        list.add(Triangle::new(2.0, 2.0, 2.0));
+
+        let total = list.total_area();
+        let expected = 6.0 + 3.0_f32.sqrt();
+        assert!(approx_eq(total, expected));
+    }
+
+    #[test]
+    fn test_total_area_empty() {
+        let list = TriangleList::new();
+        assert!(approx_eq(list.total_area(), 0.0));
+    }
+
+    #[test]
+    fn test_index_i32() {
+        let mut list = TriangleList::new();
+        list.add(Triangle::new(3.0, 4.0, 5.0));
+        list.add(Triangle::new(5.0, 5.0, 5.0));
+
+        assert_eq!(list[1_i32].number(), 1);
+        assert_eq!(list[2_i32].number(), 2);
+    }
+
+    #[test]
+    fn test_index_usize() {
+        let mut list = TriangleList::new();
+        list.add(Triangle::new(3.0, 4.0, 5.0));
+        list.add(Triangle::new(5.0, 5.0, 5.0));
+
+        assert_eq!(list[0_usize].number(), 1);
+        assert_eq!(list[1_usize].number(), 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "out of bounds")]
+    fn test_index_panic() {
+        let list = TriangleList::new();
+        let _ = list[1_i32];
+    }
+
+    #[test]
+    fn test_iterator() {
+        let mut list = TriangleList::new();
+        list.add(Triangle::new(3.0, 4.0, 5.0));
+        list.add(Triangle::new(5.0, 5.0, 5.0));
+
+        let numbers: Vec<i32> = list.iter().map(|t| t.number()).collect();
+        assert_eq!(numbers, vec![1, 2]);
+    }
+
+    #[test]
+    fn test_for_loop() {
+        let mut list = TriangleList::new();
+        list.add(Triangle::new(3.0, 4.0, 5.0));
+        list.add(Triangle::new(5.0, 5.0, 5.0));
+
+        let mut count = 0;
+        for tri in &list {
+            count += 1;
+            assert_eq!(tri.number(), count);
+        }
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn test_into_iterator() {
+        let mut list = TriangleList::new();
+        list.add(Triangle::new(3.0, 4.0, 5.0));
+        list.add(Triangle::new(5.0, 5.0, 5.0));
+
+        let triangles: Vec<Triangle> = list.into_iter().collect();
+        assert_eq!(triangles.len(), 2);
+    }
+
+    #[test]
+    fn test_first_and_last() {
+        let mut list = TriangleList::new();
+        assert!(list.first().is_none());
+        assert!(list.last().is_none());
+
+        list.add(Triangle::new(3.0, 4.0, 5.0));
+        list.add(Triangle::new(5.0, 5.0, 5.0));
+
+        assert_eq!(list.first().unwrap().number(), 1);
+        assert_eq!(list.last().unwrap().number(), 2);
+    }
+
+    #[test]
+    fn test_with_first() {
+        let list = TriangleList::with_first(Triangle::new(3.0, 4.0, 5.0));
+        assert_eq!(list.size(), 1);
+        assert_eq!(list.get(1).unwrap().number(), 1);
+    }
+
+    #[test]
+    fn test_get_mut() {
+        let mut list = TriangleList::new();
+        list.add(Triangle::new(3.0, 4.0, 5.0));
+
+        if let Some(tri) = list.get_mut(1) {
+            tri.name = "Modified".to_string();
+        }
+
+        assert_eq!(list.get(1).unwrap().name, "Modified");
+    }
+
+    #[test]
+    fn test_iter_mut() {
+        let mut list = TriangleList::new();
+        list.add(Triangle::new(3.0, 4.0, 5.0));
+        list.add(Triangle::new(5.0, 5.0, 5.0));
+
+        for tri in list.iter_mut() {
+            tri.name = format!("T{}", tri.number());
+        }
+
+        assert_eq!(list.get(1).unwrap().name, "T1");
+        assert_eq!(list.get(2).unwrap().name, "T2");
+    }
+}


### PR DESCRIPTION
Add Triangle and TriangleList structs to rust-trilib:

- Triangle: basic structure with 3 edge lengths, auto-calculated vertex positions, Heron's formula for area, and connection info
- TriangleList: collection manager with auto-numbering, 1-indexed access, Index trait (both i32 and usize), Iterator support, add/get/remove/clear/total_area methods

Includes 64 comprehensive tests covering:
- Triangle creation and validation
- Area calculation (3-4-5 and equilateral triangles)
- TriangleList operations (add, get, remove, clear)
- Iterator and Index trait implementations
- Edge cases and error conditions

All tests pass and cargo clippy reports no warnings.