### PR TITLE
Resolve merge conflict in trianglelist-web/index.html

### DIFF
--- a/trianglelist-web/index.html
+++ b/trianglelist-web/index.html
@@ -84,12 +84,8 @@
         <div class="loading-text">読み込み中...</div>
     </div>
 
-<<<<<<< HEAD
-=======
     <!-- eframe canvas element -->
     <canvas id="trianglelist-canvas"></canvas>
-
->>>>>>> origin/circleci
     <script>
         // WASM初期化完了後にローディング画面を非表示にする
         // 使用方法: Rust/WASM側から wasm_bindgen で window.hideLoading() を呼び出す


### PR DESCRIPTION
### Motivation
- Remove leftover merge conflict markers in `trianglelist-web/index.html` that would break HTML parsing and the Pages build.
- Restore the `eframe` canvas element so the WASM frontend has its expected DOM target.
- Ensure the repository's web entry is valid for `trunk build` and GitHub Pages deployment.

### Description
- Deleted Git conflict markers and surrounding noise from `trianglelist-web/index.html`.
- Kept and placed the `<canvas id="trianglelist-canvas"></canvas>` element into the page markup.
- Restored the loading hide logic to work with the cleaned HTML.

### Testing
- No automated tests were run for this change.
- Basic file inspection was used to verify the conflict markers were removed and the canvas element remains in place.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69607b7d02448320b167a67c87692f13)